### PR TITLE
feat:improve DraggableResizableAsset position and default size

### DIFF
--- a/packages/photobooth_ui/lib/src/widgets/draggable_resizable_asset.dart
+++ b/packages/photobooth_ui/lib/src/widgets/draggable_resizable_asset.dart
@@ -1,5 +1,4 @@
 import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
 import 'package:photobooth_ui/photobooth_ui.dart';
 
@@ -87,8 +86,8 @@ class _DraggableResizableAssetState extends State<DraggableResizableAsset> {
             key: const Key('draggableResizableAsset_topLeft_resizePoint'),
             onDrag: (dx, dy) {
               final mid = (dx + dy) / 2;
-              final tempNewHeight = height - 2 * mid;
-              final tempNewWidth = width - 2 * mid;
+              final tempNewHeight = (height - 2 * mid).abs();
+              final tempNewWidth = (width - 2 * mid).abs();
               if (tempNewHeight >= maxHeight || tempNewHeight <= minHeight) {
                 return;
               }

--- a/packages/photobooth_ui/test/src/widgets/draggable_resizable_asset_test.dart
+++ b/packages/photobooth_ui/test/src/widgets/draggable_resizable_asset_test.dart
@@ -86,7 +86,7 @@ void main() async {
       final firstLocation = tester.getCenter(resizePointFinder);
       await tester.dragFrom(
         firstLocation,
-        Offset(firstLocation.dx + 10, firstLocation.dy + 10),
+        Offset(firstLocation.dx - 1, firstLocation.dy - 1),
       );
       await tester.pump(kThemeAnimationDuration);
       final newSize = tester.getSize(imageFinder);


### PR DESCRIPTION
## Description

Improve default size and position for the stickers and characters assets

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
