### PR TITLE
fix: footer text styles

### DIFF
--- a/lib/footer/widgets/footer.dart
+++ b/lib/footer/widgets/footer.dart
@@ -32,10 +32,7 @@ class Footer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTextStyle(
-      style: Theme.of(context).textTheme.caption!.copyWith(
-            color: textColor,
-            fontWeight: PhotoboothFontWeight.regular,
-          ),
+      style: Theme.of(context).textTheme.caption!.copyWith(color: textColor),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(50, 0, 50, 32),
         child: ResponsiveLayoutBuilder(

--- a/packages/photobooth_ui/lib/src/typography/text_styles.dart
+++ b/packages/photobooth_ui/lib/src/typography/text_styles.dart
@@ -76,7 +76,7 @@ class PhotoboothTextStyle {
   /// Caption Text Style
   static TextStyle get caption => _baseTextStyle.copyWith(
         fontSize: 14,
-        fontWeight: PhotoboothFontWeight.medium,
+        fontWeight: PhotoboothFontWeight.regular,
       );
 
   /// Overline Text Style


### PR DESCRIPTION
## Description

- links had the wrong font-weight
- default text color wasn't passed to the `FooterMadeWithLink` widget

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
