### PR TITLE
feat(photobooth_ui): add oneTime mode to the animated sprite widget

### DIFF
--- a/packages/photobooth_ui/lib/src/widgets/animated_sprite.dart
+++ b/packages/photobooth_ui/lib/src/widgets/animated_sprite.dart
@@ -40,7 +40,10 @@ enum AnimationMode {
   trigger,
 
   /// Animations plays on a loop
-  loop
+  loop,
+
+  /// Animations plays immediately once
+  oneTime
 }
 
 /// {@template animated_sprite}
@@ -58,7 +61,7 @@ class AnimatedSprite extends StatefulWidget {
   /// The collection of sprites which will be animated.
   final Sprites sprites;
 
-  /// The mode of animation (`trigger` or `loop`).
+  /// The mode of animation (`trigger`, `loop` or `oneTime`).
   final AnimationMode mode;
 
   @override
@@ -106,7 +109,8 @@ class _AnimatedSpriteState extends State<AnimatedSprite> {
 
       setState(() {
         _status = _AnimatedSpriteStatus.loaded;
-        if (widget.mode == AnimationMode.loop) {
+        if (widget.mode == AnimationMode.loop ||
+            widget.mode == AnimationMode.oneTime) {
           _isPlaying = true;
         }
       });

--- a/packages/photobooth_ui/test/src/widgets/animated_sprite_test.dart
+++ b/packages/photobooth_ui/test/src/widgets/animated_sprite_test.dart
@@ -58,6 +58,29 @@ void main() async {
       });
     });
 
+    testWidgets('renders SpriteAnimationWidget when asset is loaded (oneTime)',
+        (tester) async {
+      await tester.runAsync(() async {
+        final images = MockImages();
+        when(() => images.load(any())).thenAnswer((_) async => image);
+        Flame.images = images;
+        await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+            body: AnimatedSprite(
+              sprites: Sprites(asset: 'test.png', size: Size(1, 1), frames: 1),
+              mode: AnimationMode.oneTime,
+            ),
+          ),
+        ));
+        await tester.pump();
+        final spriteAnimationFinder = find.byType(SpriteAnimationWidget);
+        final widget = tester.widget<SpriteAnimationWidget>(
+          spriteAnimationFinder,
+        );
+        expect(widget.playing, isTrue);
+      });
+    });
+
     testWidgets('renders SpriteAnimationWidget when asset is loaded (trigger)',
         (tester) async {
       await tester.runAsync(() async {


### PR DESCRIPTION
## Description

- added `oneTime` animation mode to the `AnimatedSprite` widget
- it will be used for photo dropping animation (#130)

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
