### PR TITLE
Use cross_file directly instead of through file_picker.

### DIFF
--- a/lib/share/bloc/share_bloc.dart
+++ b/lib/share/bloc/share_bloc.dart
@@ -4,7 +4,7 @@ import 'dart:typed_data';
 import 'package:bloc/bloc.dart';
 import 'package:camera/camera.dart';
 import 'package:equatable/equatable.dart';
-import 'package:file_selector/file_selector.dart';
+import 'package:cross_file/cross_file.dart';
 import 'package:image_compositor/image_compositor.dart';
 import 'package:io_photobooth/photobooth/photobooth.dart';
 import 'package:photos_repository/photos_repository.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -142,7 +142,7 @@ packages:
     source: hosted
     version: "1.0.2"
   cross_file:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: cross_file
       url: "https://pub.dartlang.org"
@@ -183,27 +183,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.0"
-  file_selector:
-    dependency: "direct main"
-    description:
-      name: file_selector
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.8.2"
-  file_selector_platform_interface:
-    dependency: transitive
-    description:
-      name: file_selector_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.2"
-  file_selector_web:
-    dependency: transitive
-    description:
-      name: file_selector_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.8.1"
   firebase_auth:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,8 @@ dependencies:
   bloc: ^7.0.0
   camera:
     path: packages/camera/camera
+  cross_file: ^0.3.1
   equatable: ^2.0.0
-  file_selector: ^0.8.2
   flutter_bloc: ^7.0.0
   image: ^3.0.2
   rxdart: ^0.26.0

--- a/test/share/widgets/download_button_test.dart
+++ b/test/share/widgets/download_button_test.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:bloc_test/bloc_test.dart';
-import 'package:file_selector/file_selector.dart';
+import 'package:cross_file/cross_file.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:io_photobooth/share/share.dart';

--- a/test/share/widgets/facebook_button_test.dart
+++ b/test/share/widgets/facebook_button_test.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: prefer_const_constructors
 import 'dart:typed_data';
 
-import 'package:file_selector/file_selector.dart';
+import 'package:cross_file/cross_file.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:io_photobooth/share/share.dart';
 import 'package:mocktail/mocktail.dart';

--- a/test/share/widgets/share_progress_overlay_test.dart
+++ b/test/share/widgets/share_progress_overlay_test.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: prefer_const_constructors
 import 'dart:typed_data';
 
-import 'package:file_selector/file_selector.dart';
+import 'package:cross_file/cross_file.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:io_photobooth/share/share.dart';

--- a/test/share/widgets/share_state_listener_test.dart
+++ b/test/share/widgets/share_state_listener_test.dart
@@ -3,7 +3,7 @@
 import 'dart:typed_data';
 
 import 'package:bloc_test/bloc_test.dart';
-import 'package:file_selector/file_selector.dart';
+import 'package:cross_file/cross_file.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:io_photobooth/share/share.dart';

--- a/test/share/widgets/twitter_button_test.dart
+++ b/test/share/widgets/twitter_button_test.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: prefer_const_constructors
 import 'dart:typed_data';
 
-import 'package:file_selector/file_selector.dart';
+import 'package:cross_file/cross_file.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:io_photobooth/photobooth/photobooth.dart';
 import 'package:io_photobooth/share/share.dart';


### PR DESCRIPTION
## Description

This PR removes the dependency on `file_selector`, which was there only to gain transitive access to the `XFile` class. That class is provided directly by the `cross_file` package.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
