### PR TITLE
Fix Flutter label typo in footer.ts

### DIFF
--- a/functions/src/share/templates/footer.ts
+++ b/functions/src/share/templates/footer.ts
@@ -2,7 +2,7 @@ export default `
 <footer>
   <div class="left">
     <span>Made with
-      <a href="https://flutter.dev">Futter</a> &amp;
+      <a href="https://flutter.dev">Flutter</a> &amp;
       <a href="https://firebase.google.com">Firebase</a>
     </ul>
   </div>


### PR DESCRIPTION
## Description

Footer has typo. Says Futter instead of Flutter.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
