### PR TITLE
ci: update `actions/checkout` from v2 to v3 in our GitHub workflows

### DIFF
--- a/.github/workflows/analytics.yaml
+++ b/.github/workflows/analytics.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v1.5.0
         with:

--- a/.github/workflows/authentication_repository.yaml
+++ b/.github/workflows/authentication_repository.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v1.5.0
         with:

--- a/.github/workflows/camera.yaml
+++ b/.github/workflows/camera.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v1.5.0
         with:

--- a/.github/workflows/camera_platform_interface.yaml
+++ b/.github/workflows/camera_platform_interface.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v1.5.0
         with:

--- a/.github/workflows/camera_web.yaml
+++ b/.github/workflows/camera_web.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v1.5.0
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy Development
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v1.5.0
         with:
           channel: master

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy Production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v1.5.0
         with:
           channel: master

--- a/.github/workflows/firebase_functions.yaml
+++ b/.github/workflows/firebase_functions.yaml
@@ -13,7 +13,7 @@ jobs:
         working-directory: ./functions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: "14"

--- a/.github/workflows/image_compositor.yaml
+++ b/.github/workflows/image_compositor.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v1.5.0
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v1.5.0
         with:
           channel: master

--- a/.github/workflows/photoboot_ui.yaml
+++ b/.github/workflows/photoboot_ui.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v1.5.0
         with:

--- a/.github/workflows/photos_repository.yaml
+++ b/.github/workflows/photos_repository.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v1.5.0
         with:

--- a/.github/workflows/platform_helper.yaml
+++ b/.github/workflows/platform_helper.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v1.5.0
         with:


### PR DESCRIPTION
## Description

Node 12 is deprecated for GitHub Actions. This is the reason why we are getting a warning from GitHub:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This PR updates `actions/checkout` from v2 to v3 which should fix the problem.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
